### PR TITLE
fix: english links

### DIFF
--- a/docs/guide.en-US.md
+++ b/docs/guide.en-US.md
@@ -35,7 +35,7 @@ Kraken currently does not provide a CLI program that can run on the Windows plat
 
 Use your Android phone to scan the QR code below to download Kraken Playground to experience the examples in each document.
 
-<img src="https://kraken.oss-cn-hangzhou.aliyuncs.com/images/80__46bf3eaeb94f716e0d49c3f6beddabed_c12a17e1b28794b033f4cbe64463ee5b.png" width="200px"></img>
+<img src="https://kraken.oss-cn-hangzhou.aliyuncs.com/images/80__46bf3eaeb94f716e0d49c3f6beddabed_c12a17e1b28794b033f4cbe64463ee5b.png" width="200px" alt="QR code"></img>
 
 ## Create a Kraken application
 
@@ -51,7 +51,7 @@ You can use the Rax bundle we built to run a Kraken application to experience th
 kraken http://kraken.oss-cn-hangzhou.aliyuncs.com/demo/demo-rax.js
 ```
 
-Of course, if you want to learn more about how to use Rax to develop a Kraken application, you can quickly create a Rax for Kraken application based on the `npm init rax` command. For more detailed steps, please visit [Develop Kraken Application with Rax](/guide/development/rax).
+Of course, if you want to learn more about how to use Rax to develop a Kraken application, you can quickly create a Rax for Kraken application based on the `npm init rax` command. For more detailed steps, please visit [Develop Kraken Application with Rax](/en-US/guide/development/rax).
 
 ### If you are a Vue developer
 
@@ -61,7 +61,7 @@ You can use the Vue bundle we built to run a Kraken application to experience th
 kraken http://kraken.oss-cn-hangzhou.aliyuncs.com/demo/demo-vue.js
 ```
 
-Of course, if you want to learn more about how to use Vue to develop a Kraken application, or how to transform an old project of Vue so that it can run on Kraken, you can visit [Develop Kraken Application with Vue](/guide/development/ vue).
+Of course, if you want to learn more about how to use Vue to develop a Kraken application, or how to transform an old project of Vue so that it can run on Kraken, you can visit [Develop Kraken Application with Vue](/en-US/guide/development/vue).
 
 ### If you are a React developer
 
@@ -71,4 +71,4 @@ You can use the React bundle we built to run a Kraken application to experience 
 kraken http://kraken.oss-cn-hangzhou.aliyuncs.com/demo/demo-react.js
 ```
 
-Of course, if you want to learn more about how to use React to develop a Kraken application, or how to transform an old React project so that it can run on Kraken, you can visit [Develop Kraken Application with React](/guide/development/ react).
+Of course, if you want to learn more about how to use React to develop a Kraken application, or how to transform an old React project so that it can run on Kraken, you can visit [Develop Kraken Application with React](/en-US/guide/development/react).

--- a/docs/guide/advanced/communicate-with-native.en-US.md
+++ b/docs/guide/advanced/communicate-with-native.en-US.md
@@ -2,11 +2,11 @@
 
 ## Prepare to work
 
-**[SDK Integration](/guide/native/interpolation-app)**
+**[SDK Integration](/en-US/guide/native/interpolation-app)**
 
 No additional configuration is required.
 
-**[Kraken Widget Integration](/guide/native/interpolation-flutter)**
+**[Kraken Widget Integration](/en-US/guide/native/interpolation-flutter)**
 
 You need to pass in `KrakenNativeChannel()` parameter to Kraken object to enable the communication between js and native.
 

--- a/docs/guide/advanced/gesture-to-native.en-US.md
+++ b/docs/guide/advanced/gesture-to-native.en-US.md
@@ -47,7 +47,7 @@ Kraken kraken = Kraken(
 );
 ```
 
-For detailed API calls, see [Development Document](/guide/native/widget).
+For detailed API calls, see [Development Document](/en-US/guide/native/widget).
 
 ## Touch pass
 

--- a/docs/guide/advanced/gesture.en-US.md
+++ b/docs/guide/advanced/gesture.en-US.md
@@ -42,4 +42,4 @@ Kraken expands on `GestureEvent`, adding some parameters for different gestures:
 
 Through these `GestureEvent` parameters, we can easily monitor gesture events on a specific element in the application, and learn some of the current gesture states based on the parameters, so as to quickly develop an application with complex gesture interaction.
 
-For more detailed API introduction, please see [gesture](/api/enhancement/gesture).
+For more detailed API introduction, please see [gesture](/en-US/api/enhancement/gesture).

--- a/docs/guide/advanced/high-performance-list.en-US.md
+++ b/docs/guide/advanced/high-performance-list.en-US.md
@@ -100,4 +100,4 @@ export default function ScrollView(props) {
 
 ## API Reference
 
-For more details, please jump to the [Sliver API](/api/enhancement/sliver) document to view.
+For more details, please jump to the [Sliver API](/en-US/api/enhancement/sliver) document to view.

--- a/docs/guide/basic/animation.en-US.md
+++ b/docs/guide/basic/animation.en-US.md
@@ -55,4 +55,4 @@ setTimeout(() => {
   </div>
 </div>
 
-For more detailed API, please refer to [Development Document](/api/styles/transform).
+For more detailed API, please refer to [Development Document](/en-US/api/styles/transform).

--- a/docs/guide/basic/color.en-US.md
+++ b/docs/guide/basic/color.en-US.md
@@ -1,8 +1,8 @@
 # Color and background
 
-The color `color` acts on the font, and the background `background` can act on any element (including text). For the color and background-related attributes supported by Kraken, please refer to the corresponding [Development Document](/api/styles/background).
+The color `color` acts on the font, and the background `background` can act on any element (including text). For the color and background-related attributes supported by Kraken, please refer to the corresponding [Development Document](/en-US/api/styles/background).
 
-For colors, it supports multiple formats such as color keywords, rgba, hexadecimal, etc. For details, please refer to the corresponding [Development Document](/api/styles/unit#css-color unit).
+For colors, it supports multiple formats such as color keywords, rgba, hexadecimal, etc. For details, please refer to the corresponding [Development Document](/en-US/api/styles/unit#css-color-unit).
 
 **Example:**
 

--- a/docs/guide/basic/difference-to-web.en-US.md
+++ b/docs/guide/basic/difference-to-web.en-US.md
@@ -30,7 +30,7 @@ root.appendChild(document.createTextNode('Hello World!'));
 document.body.appendChild(root);
 ```
 
-Compared to HTML, JS has more flexible features. Since the standard DOM API is implemented, you can use most of the excellent front-end frameworks in the front-end community, such as Vue, Rax, React, etc., for details, please refer to [Development Document](/guide).
+Compared to HTML, JS has more flexible features. Since the standard DOM API is implemented, you can use most of the excellent front-end frameworks in the front-end community, such as Vue, Rax, React, etc., for details, please refer to [Development Document](/en-US/guide).
 
 ## Limited CSS support
 
@@ -47,12 +47,12 @@ div.setAttribute('style', 'color: red; font-size: 16px;'); // Use inline CSS Tex
 
 In Kraken, not all DOM and global APIs are supported. Putting aside the historical baggage of browsers, we implemented most of the modern, frequently used, and user-friendly W3C APIs.
 
-For more detailed support list, please refer to [API document](/api/tags) on the site.
+For more detailed support list, please refer to [API document](/en-US/api/tags) on the site.
 
 ## Style ability difference
 
-Please refer to the [Differences from browser](/api/styles/difference) document.
+Please refer to the [Differences from browser](/en-US/api/styles/difference) document.
 
 ## Local storage
 
-In browsers, we often use `LocalStorage` for local data storage, while in Kraken we use `AsyncStorage` to implement local storage. It provides a more efficient asynchronous API to prevent I/O from blocking the UI thread. More information You can view [Asynchronous Local Storage](/api/enhancement/storage).
+In browsers, we often use `LocalStorage` for local data storage, while in Kraken we use `AsyncStorage` to implement local storage. It provides a more efficient asynchronous API to prevent I/O from blocking the UI thread. More information You can view [Asynchronous Local Storage](/en-US/api/enhancement/storage).

--- a/docs/guide/basic/layout.en-US.md
+++ b/docs/guide/basic/layout.en-US.md
@@ -109,7 +109,7 @@ For a long time, the only reliable and cross-browser compatible layout methods i
 
 Therefore, the Flexbox layout method was introduced in the CSS3 standard, which solved the limitations of many previous layout methods. For detailed concept introduction, please refer to this [document](https://developer.mozilla.org/zh-CN/docs/Learn/CSS/CSS_layout/Flexbox).
 
-For all properties related to flexbox layout supported by Kraken, please refer to [Development Document](/api/styles/layout#flexbox layout).
+For all properties related to flexbox layout supported by Kraken, please refer to [Development Document](/en-US/api/styles/layout#flexbox layout).
 
 The following uses examples to introduce simple usage:
 
@@ -240,7 +240,7 @@ CSS provides five positioning methods:
 
 5. sticky: sticky positioning, the tag is positioned according to the normal document flow, and then relative to its nearest scrolling ancestor and [containing block](https://developer.mozilla.org/zh-CN/docs/Web/CSS/Containing_block) (The nearest block-level ancestor), offset based on the values ​​of top, right, bottom and left. The offset value does not affect the position of any other labels.
 
-Please refer to [Development Document](/api/styles/position) for all the properties related to positioning supported by Kraken.
+Please refer to [Development Document](/en-US/api/styles/position) for all the properties related to positioning supported by Kraken.
 
 **Example:**
 

--- a/docs/guide/basic/multimedia.en-US.md
+++ b/docs/guide/basic/multimedia.en-US.md
@@ -45,7 +45,7 @@ Kraken supports all image formats supported by Flutter, including `JPEG, PNG, GI
 
 ## Video
 
-Video is not natively supported by Kraken. You need to install this [kraken_video_player plugin](https://pub.dev/packages/kraken_video_player) to support it. For detailed installation methods, please refer to [Development Document](/plugins/official/kraken_video_player) .
+Video is not natively supported by Kraken. You need to install this [kraken_video_player plugin](https://pub.dev/packages/kraken_video_player) to support it. For detailed installation methods, please refer to [Development Document](/en-US/plugins/official/kraken_video_player) .
 
 **Example:**
 

--- a/docs/guide/basic/network.en-US.md
+++ b/docs/guide/basic/network.en-US.md
@@ -32,7 +32,7 @@ fetch(url, {
   .then(json => console.log(json));
 ```
 
-For more information, please refer to [Development Document](/api/host-environment/fetch).
+For more information, please refer to [Development Document](/en-US/api/host-environment/fetch).
 
 ## WebSocket
 
@@ -56,7 +56,7 @@ ws.onclose = function(evt) {
 };
 ```
 
-For more details, please refer to [Development Document](/plugins/official/kraken_websocket).
+For more details, please refer to [Development Document](/en-US/plugins/official/kraken_websocket).
 
 ## Use XMLHttpRequest
 

--- a/docs/guide/basic/sizing.en-US.md
+++ b/docs/guide/basic/sizing.en-US.md
@@ -6,7 +6,7 @@ When the page is rendered, Kraken is based on the [W3C box model](https://develo
 
 Corresponding to the CSS properties, `width`, `height` describe the width and height of the label, `padding` describes the inner margin of the label, and `margin` describes the outer margin of the label.
 
-Please refer to [Development Document](/api/styles/sizing) for all the attributes related to size margins supported by Kraken.
+Please refer to [Development Document](/en-US/api/styles/sizing) for all the attributes related to size margins supported by Kraken.
 
 **Example:**
 

--- a/docs/guide/basic/style.en-US.md
+++ b/docs/guide/basic/style.en-US.md
@@ -4,7 +4,7 @@ Kraken implements W3C standard HTML tags and CSS styles, so you can use Web deve
 
 ## Build the page structure
 
-Kraken supports most of the commonly used standard HTML tags (for all supported tags, please refer to [Development Document](/api/tags)). Using these tags can help us build the basic structure of the page.
+Kraken supports most of the commonly used standard HTML tags (for all supported tags, please refer to [Development Document](/en-US/api/tags)). Using these tags can help us build the basic structure of the page.
 
 The following example demonstrates how to write a simple blog post structure using native HTML tags:
 
@@ -29,7 +29,7 @@ The following example demonstrates how to write a simple blog post structure usi
 
 ## Add style
 
-Kraken supports most of the commonly used CSS styles (for all supported styles, please refer to [Development Document](/api/styles)). Next, we will continue to add styles to the HTML code example of the blog post example above:
+Kraken supports most of the commonly used CSS styles (for all supported styles, please refer to [Development Document](/en-US/api/styles)). Next, we will continue to add styles to the HTML code example of the blog post example above:
 
 > For the convenience of demonstration, the code examples uniformly use React / Rax supported [JSX syntax](https://zh-hans.reactjs.org/docs/introducing-jsx.html) to set the inline style.
 

--- a/docs/guide/basic/timer.en-US.md
+++ b/docs/guide/basic/timer.en-US.md
@@ -39,4 +39,4 @@ let timer = setTimeout(function() {
 clearTimeout(timer);
 ```
 
-To know which timers Kraken supports, please check [Development Document](/api/host-environment/timers).
+To know which timers Kraken supports, please check [Development Document](/en-US/api/host-environment/timers).

--- a/docs/guide/basic/touch.en-US.md
+++ b/docs/guide/basic/touch.en-US.md
@@ -46,4 +46,4 @@ In applications such as Rax / React / Vue, you only need to bind the click event
 
 ## Use more advanced gesture capabilities
 
-On the Web, developers often need to encapsulate the underlying [TouchEvent](https://developer.mozilla.org/zh-CN/docs/Web/API/TouchEvent) to provide a set of higher-level gesture capabilities. Kraken has built-in these commonly used gesture abilities. For the specific usage of advanced gesture abilities, please refer to [Using Enhanced Gesture Abilities](/guide/advanced/gesture).
+On the Web, developers often need to encapsulate the underlying [TouchEvent](https://developer.mozilla.org/zh-CN/docs/Web/API/TouchEvent) to provide a set of higher-level gesture capabilities. Kraken has built-in these commonly used gesture abilities. For the specific usage of advanced gesture abilities, please refer to [Using Enhanced Gesture Abilities](/en-US/guide/advanced/gesture).

--- a/docs/guide/contribute/development.en-US.md
+++ b/docs/guide/contribute/development.en-US.md
@@ -13,7 +13,7 @@ After installing the editor, you also need to install additional Flutter plugins
 
 ## Build Bridge
 
-Before running Kraken, you also need to build the JS Bridge code locally. The bridge code is in the `bridge` directory and is implemented by C++. Before compiling, make sure to follow the instructions in [Prepare Development Environment](/guide/contribute/environment) to build the dependencies required for the build.
+Before running Kraken, you also need to build the JS Bridge code locally. The bridge code is in the `bridge` directory and is implemented by C++. Before compiling, make sure to follow the instructions in [Prepare Development Environment](/en-US/guide/contribute/environment) to build the dependencies required for the build.
 
 **macOS platform**
 

--- a/docs/plugins/plugin/introduction.en-US.md
+++ b/docs/plugins/plugin/introduction.en-US.md
@@ -6,7 +6,7 @@ Kraken's rendering capabilities can be customized through the Kraken plug-in, in
 
 The development of Kraken plug-in requires certain client development capabilities. Developers need to have a certain foundation for Android / iOS development, and also need to master the relevant skills of Flutter application development.
 
-For details, please refer to [Development Plugin](/plugins/plugin/development).
+For details, please refer to [Development Plugin](/en-US/plugins/plugin/development).
 
 ## Kraken plug-in capabilities
 


### PR DESCRIPTION
Links of the English docs were pointing to the Chinese docs instead of the translated ones. This PR fixes the issue.